### PR TITLE
Change portal coordinate system and adjust yaw

### DIFF
--- a/src/main/java/xyz/kubasz/personalspace/block/PortalTileEntity.java
+++ b/src/main/java/xyz/kubasz/personalspace/block/PortalTileEntity.java
@@ -1,10 +1,12 @@
 package xyz.kubasz.personalspace.block;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.WorldServer;
@@ -21,9 +23,10 @@ public class PortalTileEntity extends TileEntity {
 
     public boolean active = false;
     public int targetDimId = 0;
-    public int targetX = 8;
-    public int targetY = 8;
-    public int targetZ = 8;
+    public int targetPosX = 8;
+    public int targetPosY = 8;
+    public int targetPosZ = 8;
+    public ForgeDirection targetFacing = DEFAULT_FACING;
     public ForgeDirection facing = DEFAULT_FACING;
 
     public PortalTileEntity() {}
@@ -47,9 +50,9 @@ public class PortalTileEntity extends TileEntity {
         if (tag.hasKey("remotePos")) {
             isLegacy = true;
             int[] pos_array = tag.getIntArray("remotePos");
-            this.targetX = pos_array[0];
-            this.targetY = pos_array[1];
-            this.targetZ = pos_array[2];
+            this.targetPosX = pos_array[0];
+            this.targetPosY = pos_array[1];
+            this.targetPosZ = pos_array[2];
         }
         if (tag.hasKey("remoteDir")) {
             isLegacy = true;
@@ -68,8 +71,6 @@ public class PortalTileEntity extends TileEntity {
                     this.facing = ForgeDirection.SOUTH;
                     break;
             }
-            this.targetX += 1;
-            this.targetZ += 1;
         }
         if (tag.hasKey("localDimensionId")) {
             isLegacy = true;
@@ -84,18 +85,21 @@ public class PortalTileEntity extends TileEntity {
         if (tag.hasKey("target")) {
             int[] t_array = tag.getIntArray("target");
             this.targetDimId = t_array[0];
-            this.targetX = t_array[1];
-            this.targetY = t_array[2];
-            this.targetZ = t_array[3];
+            this.targetPosX = t_array[1];
+            this.targetPosY = t_array[2];
+            this.targetPosZ = t_array[3];
         }
         if (tag.hasKey("facing")) {
             facing = ForgeDirection.getOrientation(tag.getInteger("facing"));
+        }
+        if (tag.hasKey("targetFacing")) {
+            targetFacing = ForgeDirection.getOrientation(tag.getInteger("targetFacing"));
         }
 
         if (isLegacy) {
             this.active = true;
             PersonalSpaceMod.LOG.info(
-                    "Migrated old UW portal to dim {} : target {},{},{}", targetDimId, targetX, targetY, targetZ);
+                    "Migrated old UW portal to dim {} : target {},{},{}", targetDimId, targetPosX, targetPosY, targetPosZ);
             markDirty();
         }
         if (facing == ForgeDirection.UNKNOWN) {
@@ -115,8 +119,9 @@ public class PortalTileEntity extends TileEntity {
     public void writeToNBT(NBTTagCompound tag) {
         super.writeToNBT(tag);
         tag.setBoolean("active", this.active);
-        tag.setIntArray("target", new int[] {this.targetDimId, this.targetX, this.targetY, this.targetZ});
+        tag.setIntArray("target", new int[] {this.targetDimId, this.targetPosX, this.targetPosY, this.targetPosZ});
         tag.setInteger("facing", this.facing.ordinal());
+        tag.setInteger("targetFacing", this.targetFacing.ordinal());
     }
 
     @Override
@@ -138,9 +143,26 @@ public class PortalTileEntity extends TileEntity {
         if (worldObj.isRemote || !this.active) {
             return;
         }
+        WorldServer targetDimension = getTargetDimension();
+        PersonalTeleporter tp = new PersonalTeleporter(this, targetDimension, (WorldServer) worldObj);
 
-        PersonalTeleporter tp = new PersonalTeleporter((WorldServer) worldObj, targetX, targetY, targetZ);
         player.mcServer.getConfigurationManager().transferPlayerToDimension(player, this.targetDimId, tp);
+    }
+
+    public int getTargetTeleportX() {
+        return targetPosX + targetFacing.offsetX;
+    }
+
+    public int getTargetTeleportY() {
+        return targetPosY + targetFacing.offsetY;
+    }
+
+    public int getTargetTeleportZ() {
+        return targetPosZ + targetFacing.offsetZ;
+    }
+
+    public WorldServer getTargetDimension() {
+        return MinecraftServer.getServer().worldServerForDimension(targetDimId);
     }
 
     public void linkOtherPortal(boolean spawnNewPortal, EntityPlayerMP player) {
@@ -159,12 +181,12 @@ public class PortalTileEntity extends TileEntity {
             PersonalSpaceMod.LOG.fatal("Couldn't initialize world {}", this.targetDimId);
             return;
         }
-        int otherX = targetX, otherY = targetY, otherZ = targetZ;
+        int otherX = targetPosX, otherY = targetPosY, otherZ = targetPosZ;
         searchloop:
-        for (otherX = targetX - 1; otherX <= targetX + 1; otherX++) {
-            for (otherY = targetY - 1; otherY <= targetY + 1; otherY++) {
+        for (otherX = targetPosX - 1; otherX <= targetPosX + 1; otherX++) {
+            for (otherY = targetPosY - 1; otherY <= targetPosY + 1; otherY++) {
                 if (otherY < 0 || otherY > otherWorld.getHeight()) continue;
-                for (otherZ = targetZ - 1; otherZ <= targetZ + 1; otherZ++) {
+                for (otherZ = targetPosZ - 1; otherZ <= targetPosZ + 1; otherZ++) {
                     if (!otherWorld.blockExists(otherX, otherY, otherZ)) {
                         otherWorld.theChunkProviderServer.loadChunk(otherX >> 4, otherZ >> 4);
                     }
@@ -182,9 +204,9 @@ public class PortalTileEntity extends TileEntity {
                 otherPortal = (PortalTileEntity) wte;
             }
         } else if (spawnNewPortal) {
-            otherX = targetX;
-            otherY = targetY;
-            otherZ = targetZ;
+            otherX = targetPosX;
+            otherY = targetPosY;
+            otherZ = targetPosZ;
             otherWorld.setBlock(otherX, otherY, otherZ, PersonalSpaceMod.BLOCK_PORTAL, facing.ordinal(), 3);
             otherPortal = (PortalTileEntity) otherWorld.getTileEntity(otherX, otherY, otherZ);
         }
@@ -198,9 +220,10 @@ public class PortalTileEntity extends TileEntity {
                 return;
             }
             otherPortal.targetDimId = worldObj.provider.dimensionId;
-            otherPortal.targetX = xCoord + facing.offsetX;
-            otherPortal.targetY = yCoord + facing.offsetY;
-            otherPortal.targetZ = zCoord + facing.offsetZ;
+            otherPortal.targetPosX = xCoord;
+            otherPortal.targetPosY = yCoord;
+            otherPortal.targetPosZ = zCoord;
+            otherPortal.targetFacing = facing;
             otherPortal.markDirty();
             if (player != null) {
                 player.addChatMessage(new ChatComponentTranslation("chat.personalWorld.relinked", targetDimId));
@@ -261,9 +284,7 @@ public class PortalTileEntity extends TileEntity {
             PersonalSpaceMod.INSTANCE.onDimSettingsChangeServer(targetDimId);
             this.active = true;
             this.targetDimId = targetDimId;
-            this.targetX = 8 + DEFAULT_FACING.offsetX;
-            this.targetY = sanitized.getGroundLevel() + 1 + DEFAULT_FACING.offsetY;
-            this.targetZ = 8 + DEFAULT_FACING.offsetZ;
+            this.targetPosY = sanitized.getGroundLevel() + 1;
             markDirty();
             createdNewDim = true;
 

--- a/src/main/java/xyz/kubasz/personalspace/block/PortalTileEntity.java
+++ b/src/main/java/xyz/kubasz/personalspace/block/PortalTileEntity.java
@@ -1,6 +1,5 @@
 package xyz.kubasz.personalspace.block;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
@@ -99,7 +98,11 @@ public class PortalTileEntity extends TileEntity {
         if (isLegacy) {
             this.active = true;
             PersonalSpaceMod.LOG.info(
-                    "Migrated old UW portal to dim {} : target {},{},{}", targetDimId, targetPosX, targetPosY, targetPosZ);
+                    "Migrated old UW portal to dim {} : target {},{},{}",
+                    targetDimId,
+                    targetPosX,
+                    targetPosY,
+                    targetPosZ);
             markDirty();
         }
         if (facing == ForgeDirection.UNKNOWN) {

--- a/src/main/java/xyz/kubasz/personalspace/block/PortalTileEntity.java
+++ b/src/main/java/xyz/kubasz/personalspace/block/PortalTileEntity.java
@@ -5,7 +5,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.WorldServer;
@@ -146,8 +145,8 @@ public class PortalTileEntity extends TileEntity {
         if (worldObj.isRemote || !this.active) {
             return;
         }
-        WorldServer targetDimension = getTargetDimension();
-        PersonalTeleporter tp = new PersonalTeleporter(this, targetDimension, (WorldServer) worldObj);
+
+        PersonalTeleporter tp = new PersonalTeleporter(this, (WorldServer) worldObj);
 
         player.mcServer.getConfigurationManager().transferPlayerToDimension(player, this.targetDimId, tp);
     }
@@ -162,10 +161,6 @@ public class PortalTileEntity extends TileEntity {
 
     public int getTargetTeleportZ() {
         return targetPosZ + targetFacing.offsetZ;
-    }
-
-    public WorldServer getTargetDimension() {
-        return MinecraftServer.getServer().worldServerForDimension(targetDimId);
     }
 
     public void linkOtherPortal(boolean spawnNewPortal, EntityPlayerMP player) {

--- a/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
+++ b/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
@@ -1,12 +1,18 @@
 package xyz.kubasz.personalspace.world;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.Teleporter;
 import net.minecraft.world.WorldServer;
+import xyz.kubasz.personalspace.block.PortalTileEntity;
+
 
 public class PersonalTeleporter extends Teleporter {
 
     int x, y, z;
+    private WorldServer targetDimension;
+    private PortalTileEntity sourceTeleporter;
 
     public PersonalTeleporter(WorldServer world, int x, int y, int z) {
         super(world);
@@ -15,22 +21,59 @@ public class PersonalTeleporter extends Teleporter {
         this.z = z;
     }
 
+    public PersonalTeleporter(PortalTileEntity sourceTeleporter, WorldServer targetDimension, WorldServer world) {
+        super(world);
+        this.targetDimension = targetDimension;
+        this.sourceTeleporter = sourceTeleporter;
+        this.x = sourceTeleporter.getTargetTeleportX();
+        this.y = sourceTeleporter.getTargetTeleportY();
+        this.z = sourceTeleporter.getTargetTeleportZ();
+    }
+
     @Override
-    public void placeInPortal(Entity entity, double x, double y, double z, float yaw) {
-        entity.setLocationAndAngles(this.x + 0.2, this.y + 0.1, this.z + 0.2, yaw, 0.0F);
+    public void placeInPortal(Entity entity, double entityPosX, double entityPosY, double entityPosZ, float yaw) {
+        if (!this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw))
+        {
+            this.makePortal(entity);
+            this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw);
+        }
+    }
+
+    @Override
+    public boolean placeInExistingPortal(Entity entity, double entityPosX, double entityPosY, double entityPosZ, float yaw) {
+        if (sourceTeleporter != null) {
+
+            if (!targetPortalExist()) {
+                return false;
+            }
+
+            double dX = sourceTeleporter.targetPosX - sourceTeleporter.getTargetTeleportX();
+            double dZ = sourceTeleporter.targetPosZ - sourceTeleporter.getTargetTeleportZ();
+            double distanceXZ = Math.sqrt(dX * dX + dZ * dZ);
+            double newYaw = Math.acos(dX / distanceXZ) * 180 / Math.PI - 90;
+
+            if (dZ < 0) {
+                newYaw = newYaw - 180;
+            }
+
+            yaw = (float) newYaw;
+        }
+
+        entity.setLocationAndAngles(x + 0.5, y + 0.1, z + 0.5, yaw, 0.0F);
         entity.motionX = 0.0F;
         entity.motionY = 0.0F;
         entity.motionZ = 0.0F;
-    }
-
-    @Override
-    public boolean placeInExistingPortal(
-            Entity p_77184_1_, double p_77184_2_, double p_77184_4_, double p_77184_6_, float p_77184_8_) {
         return true;
     }
 
+    private boolean targetPortalExist() {
+        TileEntity tileEntity = targetDimension.getTileEntity(sourceTeleporter.targetPosX, sourceTeleporter.targetPosY, sourceTeleporter.targetPosZ);
+        return tileEntity instanceof PortalTileEntity;
+    }
+
     @Override
-    public boolean makePortal(Entity p_85188_1_) {
+    public boolean makePortal(Entity player) {
+        sourceTeleporter.linkOtherPortal(true, (EntityPlayerMP) player);
         return true;
     }
 

--- a/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
+++ b/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
@@ -2,7 +2,6 @@ package xyz.kubasz.personalspace.world;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.Teleporter;
 import net.minecraft.world.WorldServer;
 import xyz.kubasz.personalspace.block.PortalTileEntity;
@@ -67,8 +66,17 @@ public class PersonalTeleporter extends Teleporter {
     }
 
     private boolean targetPortalExist() {
-        TileEntity tileEntity = targetDimension.getTileEntity(sourceTeleporter.targetPosX, sourceTeleporter.targetPosY, sourceTeleporter.targetPosZ);
-        return tileEntity instanceof PortalTileEntity;
+        for (int x = sourceTeleporter.targetPosX - 1; x <= sourceTeleporter.targetPosX + 1; x++) {
+            for (int y = sourceTeleporter.targetPosY - 1; y <= sourceTeleporter.targetPosY + 1; y++) {
+                if (y < 0 || y > targetDimension.getHeight()) continue;
+                for (int z = sourceTeleporter.targetPosZ - 1; z <= sourceTeleporter.targetPosZ + 1; z++) {
+                    if (targetDimension.getTileEntity(x,y,z) instanceof PortalTileEntity) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
+++ b/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
@@ -6,7 +6,6 @@ import net.minecraft.world.Teleporter;
 import net.minecraft.world.WorldServer;
 import xyz.kubasz.personalspace.block.PortalTileEntity;
 
-
 public class PersonalTeleporter extends Teleporter {
 
     int x, y, z;
@@ -31,15 +30,15 @@ public class PersonalTeleporter extends Teleporter {
 
     @Override
     public void placeInPortal(Entity entity, double entityPosX, double entityPosY, double entityPosZ, float yaw) {
-        if (!this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw))
-        {
+        if (!this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw)) {
             this.makePortal(entity);
             this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw);
         }
     }
 
     @Override
-    public boolean placeInExistingPortal(Entity entity, double entityPosX, double entityPosY, double entityPosZ, float yaw) {
+    public boolean placeInExistingPortal(
+            Entity entity, double entityPosX, double entityPosY, double entityPosZ, float yaw) {
         if (sourceTeleporter != null) {
 
             if (!targetPortalExist()) {
@@ -70,7 +69,7 @@ public class PersonalTeleporter extends Teleporter {
             for (int y = sourceTeleporter.targetPosY - 1; y <= sourceTeleporter.targetPosY + 1; y++) {
                 if (y < 0 || y > targetDimension.getHeight()) continue;
                 for (int z = sourceTeleporter.targetPosZ - 1; z <= sourceTeleporter.targetPosZ + 1; z++) {
-                    if (targetDimension.getTileEntity(x,y,z) instanceof PortalTileEntity) {
+                    if (targetDimension.getTileEntity(x, y, z) instanceof PortalTileEntity) {
                         return true;
                     }
                 }

--- a/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
+++ b/src/main/java/xyz/kubasz/personalspace/world/PersonalTeleporter.java
@@ -1,7 +1,6 @@
 package xyz.kubasz.personalspace.world;
 
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.Teleporter;
 import net.minecraft.world.WorldServer;
 import xyz.kubasz.personalspace.block.PortalTileEntity;
@@ -9,7 +8,6 @@ import xyz.kubasz.personalspace.block.PortalTileEntity;
 public class PersonalTeleporter extends Teleporter {
 
     int x, y, z;
-    private WorldServer targetDimension;
     private PortalTileEntity sourceTeleporter;
 
     public PersonalTeleporter(WorldServer world, int x, int y, int z) {
@@ -19,9 +17,8 @@ public class PersonalTeleporter extends Teleporter {
         this.z = z;
     }
 
-    public PersonalTeleporter(PortalTileEntity sourceTeleporter, WorldServer targetDimension, WorldServer world) {
+    public PersonalTeleporter(PortalTileEntity sourceTeleporter, WorldServer world) {
         super(world);
-        this.targetDimension = targetDimension;
         this.sourceTeleporter = sourceTeleporter;
         this.x = sourceTeleporter.getTargetTeleportX();
         this.y = sourceTeleporter.getTargetTeleportY();
@@ -30,20 +27,13 @@ public class PersonalTeleporter extends Teleporter {
 
     @Override
     public void placeInPortal(Entity entity, double entityPosX, double entityPosY, double entityPosZ, float yaw) {
-        if (!this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw)) {
-            this.makePortal(entity);
-            this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw);
-        }
+        this.placeInExistingPortal(entity, entityPosX, entityPosY, entityPosZ, yaw);
     }
 
     @Override
     public boolean placeInExistingPortal(
             Entity entity, double entityPosX, double entityPosY, double entityPosZ, float yaw) {
         if (sourceTeleporter != null) {
-
-            if (!targetPortalExist()) {
-                return false;
-            }
 
             double dX = sourceTeleporter.targetPosX - sourceTeleporter.getTargetTeleportX();
             double dZ = sourceTeleporter.targetPosZ - sourceTeleporter.getTargetTeleportZ();
@@ -64,23 +54,8 @@ public class PersonalTeleporter extends Teleporter {
         return true;
     }
 
-    private boolean targetPortalExist() {
-        for (int x = sourceTeleporter.targetPosX - 1; x <= sourceTeleporter.targetPosX + 1; x++) {
-            for (int y = sourceTeleporter.targetPosY - 1; y <= sourceTeleporter.targetPosY + 1; y++) {
-                if (y < 0 || y > targetDimension.getHeight()) continue;
-                for (int z = sourceTeleporter.targetPosZ - 1; z <= sourceTeleporter.targetPosZ + 1; z++) {
-                    if (targetDimension.getTileEntity(x, y, z) instanceof PortalTileEntity) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
     @Override
     public boolean makePortal(Entity player) {
-        sourceTeleporter.linkOtherPortal(true, (EntityPlayerMP) player);
         return true;
     }
 


### PR DESCRIPTION
1. Use target tile coordinates instead of target teleport coordinates
2. Properly calculate yaw so player always expect to spawn looking at the portal
3. Replace target portal if missing (closes GTNewHorizons/GT-New-Horizons-Modpack#10855)
