### PR TITLE
Add Garden_Of_Glass as a new skytype

### DIFF
--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
@@ -39,8 +39,7 @@ public class DimensionConfig {
         VANILLA(null, null),
         BARNADA_C("galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.SkyProviderBarnardaC",
                 "galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.CloudProviderBarnardaC"),
-        GARDEN_OF_GLASS("vazkii.botania.client.render.world.SkyblockSkyRenderer",
-                null),;
+        GARDEN_OF_GLASS("vazkii.botania.client.render.world.SkyblockSkyRenderer", null),;
 
         public final String skyProvider, cloudProvider;
         private Boolean isLoaded = null;

--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
@@ -59,8 +59,10 @@ public class DimensionConfig {
             }
             if (isLoaded == null) {
                 try {
-                    Class<?> skyClass = Class.forName(skyProvider);
-                    Class<?> cloudClass = Class.forName(cloudProvider);
+                    Class<?> skyClass;
+                    if (skyProvider != null) skyClass = Class.forName(skyProvider);
+                    Class<?> cloudClass;
+                    if (cloudProvider != null) cloudClass = Class.forName(cloudProvider);
                     isLoaded = Boolean.TRUE;
                 } catch (ClassNotFoundException e) {
                     isLoaded = Boolean.FALSE;

--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
@@ -38,7 +38,7 @@ public class DimensionConfig {
 
         VANILLA(null, null),
         BARNADA_C("galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.SkyProviderBarnardaC",
-                "galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.CloudProviderBarnardaC")
+                "galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.CloudProviderBarnardaC"),
         GARDEN_OF_GLASS("vazkii.botania.client.render.world.SkyblockSkyRenderer",
                 null),;
 

--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
@@ -38,7 +38,9 @@ public class DimensionConfig {
 
         VANILLA(null, null),
         BARNADA_C("galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.SkyProviderBarnardaC",
-                "galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.CloudProviderBarnardaC"),;
+                "galaxyspace.BarnardsSystem.planets.barnardaC.dimension.sky.CloudProviderBarnardaC")
+        GARDEN_OF_GLASS("vazkii.botania.client.render.world.SkyblockSkyRenderer",
+                null),;
 
         public final String skyProvider, cloudProvider;
         private Boolean isLoaded = null;

--- a/src/main/resources/assets/personalspace/lang/en_US.lang
+++ b/src/main/resources/assets/personalspace/lang/en_US.lang
@@ -32,6 +32,7 @@ gui.personalWorld.notAllowed=Not allowed by the server's configuration
 
 gui.personalWorld.skyType.VANILLA=Vanilla sky
 gui.personalWorld.skyType.BARNADA_C=Barnada C sky
+gui.personalWorld.skyType.GARDEN_OF_GLASS=Garden of Glass sky
 
 commands.pspace.usage=/pspace (give-portal player DIM [X] [Y] [Z])|(tpx player DIM [X Y Z])|(ls)|(where player)|(allow-worldgen-change DIM)
 commands.pspace.badDimension=The specified dimension doesn't exist

--- a/src/main/resources/assets/personalspace/lang/zh_CN.lang
+++ b/src/main/resources/assets/personalspace/lang/zh_CN.lang
@@ -30,6 +30,7 @@ gui.personalWorld.notAllowed=服务器配置不允许
 
 gui.personalWorld.skyType.VANILLA=原版天空
 gui.personalWorld.skyType.BARNADA_C=巴纳德C天空
+gui.personalWorld.skyType.GARDEN_OF_GLASS=水晶花园天空
 
 commands.pspace.usage=/pspace (give-portal <玩家> <维度> [X] [Y] [Z])|(tpx <玩家> <维度> [X Y Z])|(ls)|(where <玩家>)|(allow-worldgen-change <维度>)
 commands.pspace.badDimension=指定维度不存在


### PR DESCRIPTION
Garden_Of_Glass is a sky render in Botania (which is available in GTNH modpack). It's only available in Botania sky island mode

![2024-06-17_20 55 18](https://github.com/GTNewHorizons/PersonalSpace/assets/17870449/ca03baba-dd93-41f8-b9b1-b800f014b474)
