### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -15,11 +15,7 @@
       "credits": "",
       "logoFile": "",
       "screenshots": [],
-      "parent": "",
-      "requiredMods": [],
-      "dependencies": [],
-      "dependants": [],
-      "useDependencyInformation": true
+      "parent": ""
     }
   ]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.