### PR TITLE
Add applyToAllSurfaceLayers generation option

### DIFF
--- a/src/main/java/me/eigenraven/personalspace/gui/GuiEditWorld.java
+++ b/src/main/java/me/eigenraven/personalspace/gui/GuiEditWorld.java
@@ -77,6 +77,7 @@ public class GuiEditWorld extends GuiScreen {
     public WBlockDropdown gapBlockADropdown;
     public WBlockDropdown gapBlockBDropdown;
     public WBlockDropdown gapBlockCDropdown;
+    public WToggleButton applyToAllSurfaceLayersToggle;
 
     public WToggleButton centerEnabledToggle;
     public WButton centerDirectionButton;
@@ -411,6 +412,12 @@ public class GuiEditWorld extends GuiScreen {
         }
     }
 
+    private void updateApplyToAllSurfaceLayersButton() {
+        if (applyToAllSurfaceLayersToggle != null) {
+            applyToAllSurfaceLayersToggle.setValue(desiredConfig.isApplyToAllSurfaceLayers());
+        }
+    }
+
     private int parseIntOrDefault(String s, int def) {
         try {
             return Integer.parseInt(s.trim());
@@ -451,6 +458,7 @@ public class GuiEditWorld extends GuiScreen {
         this.desiredConfig.setGapMetaB(0);
         this.desiredConfig.setGapBlockC("");
         this.desiredConfig.setGapMetaC(0);
+        this.desiredConfig.setApplyToAllSurfaceLayers(false);
         this.desiredConfig.setCenterEnabled(false);
         this.desiredConfig.setCenterBlock("");
         this.desiredConfig.setCenterMeta(0);
@@ -465,6 +473,7 @@ public class GuiEditWorld extends GuiScreen {
         }
         updateBoundaryButtons();
         updateGapButtons();
+        updateApplyToAllSurfaceLayersButton();
         updateCenterButtons();
     }
 
@@ -1030,6 +1039,25 @@ public class GuiEditWorld extends GuiScreen {
         rootWidget.addChild(this.gapBlockCDropdown);
 
         this.ySize += 24;
+
+        this.applyToAllSurfaceLayersToggle = new WToggleButton(
+                new Rectangle(0, this.ySize, 18, 18),
+                "",
+                false,
+                0,
+                desiredConfig.isApplyToAllSurfaceLayers(),
+                () -> {
+                    desiredConfig.setApplyToAllSurfaceLayers(applyToAllSurfaceLayersToggle.getValue());
+                    configToPreset();
+                });
+        WLabel applyToAllSurfaceLayersLabel = new WLabel(
+                24,
+                4,
+                I18n.format("gui.personalWorld.applyToAllSurfaceLayers"),
+                false);
+        this.applyToAllSurfaceLayersToggle.addChild(applyToAllSurfaceLayersLabel);
+        addWidget(this.applyToAllSurfaceLayersToggle);
+
         updateGapButtons();
 
         // Center marker section
@@ -1326,6 +1354,7 @@ public class GuiEditWorld extends GuiScreen {
         this.gapBlockADropdown.enabled = gapEnabled && !gapIsSolid;
         this.gapBlockBDropdown.enabled = gapEnabled && !gapIsSolid;
         this.gapBlockCDropdown.enabled = gapEnabled && !gapIsSolid;
+        this.applyToAllSurfaceLayersToggle.enabled = generationEnabled;
 
         boolean centerCanEnable = generationEnabled && !boundaryIsZero;
         this.centerEnabledToggle.enabled = centerCanEnable;
@@ -1358,6 +1387,7 @@ public class GuiEditWorld extends GuiScreen {
                 this.syncExtendedInputsFromDesiredConfig();
                 updateBoundaryButtons();
                 updateGapButtons();
+                updateApplyToAllSurfaceLayersButton();
                 updateCenterButtons();
             } else {
                 clearExtendedPresetInputs();

--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
@@ -199,6 +199,7 @@ public class DimensionConfig {
     private int gapMetaB = 0;
     private String gapBlockC = "minecraft:wool";
     private int gapMetaC = 0;
+    private boolean applyToAllSurfaceLayers = false;
 
     private boolean centerEnabled = false;
     private CenterDirection centerDirection = CenterDirection.SE;
@@ -230,6 +231,7 @@ public class DimensionConfig {
         final String VISUAL = "visual";
         final String WORLDGEN = "worldgen";
         final String BOUNDARY = "boundary";
+        final String GAP = "gap";
         Configuration cfg = new Configuration(file);
         Property cur;
 
@@ -325,6 +327,22 @@ public class DimensionConfig {
             setLayers(cur.getString());
         }
 
+        boolean applyToAllSurfaceLayersDefault = isApplyToAllSurfaceLayers();
+        if (!write && cfg.hasKey(GAP, "onExposedSurfaces")) {
+            applyToAllSurfaceLayersDefault = cfg.getCategory(GAP).get("onExposedSurfaces").getBoolean();
+            needsSaving = true;
+        }
+        cur = cfg.get(
+                WORLDGEN,
+                "applyToAllSurfaceLayers",
+                applyToAllSurfaceLayersDefault,
+                "Apply boundary, gap, and center marker generation to every solid layer with air above it instead of only at ground level");
+        if (write) {
+            cur.set(isApplyToAllSurfaceLayers());
+        } else {
+            setApplyToAllSurfaceLayers(cur.getBoolean());
+        }
+
         cur = cfg.get(BOUNDARY, "blockA", getBoundaryBlockA());
         if (write) {
             cur.set(getBoundaryBlockA());
@@ -366,8 +384,6 @@ public class DimensionConfig {
         } else {
             setBoundaryChunkIntervalZ(cur.getInt());
         }
-
-        final String GAP = "gap";
 
         cur = cfg.get(GAP, "width", getGapWidth(), "", 0, 5);
         if (write) {
@@ -423,6 +439,10 @@ public class DimensionConfig {
             cur.set(getGapMetaC());
         } else {
             setGapMetaC(cur.getInt());
+        }
+
+        if (write && cfg.hasKey(GAP, "onExposedSurfaces")) {
+            cfg.getCategory(GAP).remove("onExposedSurfaces");
         }
 
         final String CENTER = "center";
@@ -554,6 +574,7 @@ public class DimensionConfig {
             this.setGapMetaB(source.getGapMetaB());
             this.setGapBlockC(source.getGapBlockC());
             this.setGapMetaC(source.getGapMetaC());
+            this.setApplyToAllSurfaceLayers(source.isApplyToAllSurfaceLayers());
 
             this.setCenterEnabled(source.isCenterEnabled());
             this.setCenterDirection(source.getCenterDirection());
@@ -973,9 +994,10 @@ public class DimensionConfig {
     /**
      * Encodes all generation settings (layers + boundary + gap + center) into a single string for copy/paste
      * convenience. Format:
-     * layers_part|B,blockA,blockB,intervalX,intervalZ|G,width,preset,blockA,blockB,blockC|C,enabled,dir,block where
-     * each block is modid:name or modid:name:meta (meta omitted if 0). The center section is omitted when no center
-     * marker block is configured.
+     * layers_part|B,blockA,blockB,intervalX,intervalZ|G,width,preset,blockA,blockB,blockC|S,allSurfaces|C,enabled,dir,block
+     * where each block is modid:name or modid:name:meta (meta omitted if 0), and allSurfaces is 0 or 1. The center
+     * section is omitted when no center marker block is configured. For compatibility, old preset strings may omit the
+     * S section.
      */
     public String getFullPresetString() {
         StringBuilder sb = new StringBuilder();
@@ -991,6 +1013,9 @@ public class DimensionConfig {
         sb.append(encodeBlock(getGapBlockA(), getGapMetaA())).append(',');
         sb.append(encodeBlock(getGapBlockB(), getGapMetaB())).append(',');
         sb.append(encodeBlock(getGapBlockC(), getGapMetaC()));
+        // Apply-to-surfaces section
+        sb.append("|S,");
+        sb.append(isApplyToAllSurfaceLayers() ? 1 : 0);
         // Center section
         if (isCenterEnabled() && !getCenterBlock().isEmpty()) {
             sb.append("|C,");
@@ -1068,6 +1093,12 @@ public class DimensionConfig {
                         ParsedBlock gC = parseBlock(parts[5]);
                         target.setGapBlockC(gC.blockName());
                         target.setGapMetaC(gC.meta());
+                        break;
+                    case "S":
+                        if (parts.length < 2 || parts[1].isEmpty()) {
+                            return false;
+                        }
+                        target.setApplyToAllSurfaceLayers(Integer.parseInt(parts[1]) != 0);
                         break;
                     case "C":
                         if (parts.length < 4 || parts[1].isEmpty() || parts[2].isEmpty() || parts[3].isEmpty()) {
@@ -1401,6 +1432,17 @@ public class DimensionConfig {
 
     public Block getGapBlockCResolved() {
         return blockFromString(gapBlockC);
+    }
+
+    public boolean isApplyToAllSurfaceLayers() {
+        return applyToAllSurfaceLayers;
+    }
+
+    public void setApplyToAllSurfaceLayers(boolean applyToAllSurfaceLayers) {
+        if (this.applyToAllSurfaceLayers != applyToAllSurfaceLayers) {
+            this.needsSaving = true;
+            this.applyToAllSurfaceLayers = applyToAllSurfaceLayers;
+        }
     }
 
     public boolean isCenterEnabled() {

--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
@@ -336,7 +336,7 @@ public class DimensionConfig {
                 WORLDGEN,
                 "applyToAllSurfaceLayers",
                 applyToAllSurfaceLayersDefault,
-                "Apply boundary, gap, and center marker generation to every solid layer with air above it instead of only at ground level");
+                "Apply boundary, gap, and center marker generation to every surface layer instead of only at ground level. A surface layer is a non-air layer with air directly above it");
         if (write) {
             cur.set(isApplyToAllSurfaceLayers());
         } else {

--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfig.java
@@ -1050,6 +1050,7 @@ public class DimensionConfig {
 
         DimensionConfig parsedConfig = new DimensionConfig();
         parsedConfig.copyFrom(this, false, false, true);
+        parsedConfig.setApplyToAllSurfaceLayers(false);
         if (!applyExtendedSettingsSections(fullPreset.split("\\|"), parsedConfig)) {
             return;
         }

--- a/src/main/java/me/eigenraven/personalspace/world/DimensionConfigPackets.java
+++ b/src/main/java/me/eigenraven/personalspace/world/DimensionConfigPackets.java
@@ -47,6 +47,7 @@ public class DimensionConfigPackets {
         pkt.writeVarInt(config.getGapMetaB());
         pkt.writeString(config.getGapBlockC());
         pkt.writeVarInt(config.getGapMetaC());
+        pkt.writeBoolean(config.isApplyToAllSurfaceLayers());
 
         pkt.writeBoolean(config.isCenterEnabled());
         pkt.writeVarInt(config.getCenterDirection().ordinal());
@@ -84,6 +85,7 @@ public class DimensionConfigPackets {
         config.setGapMetaB(pkt.readVarInt());
         config.setGapBlockC(pkt.readString());
         config.setGapMetaC(pkt.readVarInt());
+        config.setApplyToAllSurfaceLayers(pkt.readBoolean());
 
         config.setCenterEnabled(pkt.readBoolean());
         config.setCenterDirection(DimensionConfig.CenterDirection.fromOrdinal(pkt.readVarInt()));

--- a/src/main/java/me/eigenraven/personalspace/world/PersonalChunkProvider.java
+++ b/src/main/java/me/eigenraven/personalspace/world/PersonalChunkProvider.java
@@ -320,13 +320,15 @@ public class PersonalChunkProvider implements IChunkProvider {
             }
         }
 
-        List<Integer> exposed = new ArrayList<>();
+        List<Integer> surfaceLevels = new ArrayList<>();
+        // A surface layer is a non-air layer with air directly above it.
+        // In air;stone*3;air, only the top stone layer is a surface layer.
         for (int y = 0; y < worldHeight; y++) {
             if (solid[y] && (y + 1 >= worldHeight || !solid[y + 1])) {
-                exposed.add(y);
+                surfaceLevels.add(y);
             }
         }
-        return exposed;
+        return surfaceLevels;
     }
 
     @Desugar

--- a/src/main/java/me/eigenraven/personalspace/world/PersonalChunkProvider.java
+++ b/src/main/java/me/eigenraven/personalspace/world/PersonalChunkProvider.java
@@ -1,5 +1,6 @@
 package me.eigenraven.personalspace.world;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -91,7 +92,8 @@ public class PersonalChunkProvider implements IChunkProvider {
 
         int groundLevel = cfg.getGroundLevel() - 1;
         if (groundLevel >= 0 && groundLevel < worldHeight) {
-            int bYChunk = groundLevel >> 4;
+            List<Integer> surfaceLevels = cfg.isApplyToAllSurfaceLayers() ? getExposedSurfaceLevels(layers, worldHeight)
+                    : Collections.singletonList(groundLevel);
 
             int intervalX = MathHelper.clamp_int(cfg.getBoundaryChunkIntervalX(), 0, 20);
             int intervalZ = MathHelper.clamp_int(cfg.getBoundaryChunkIntervalZ(), 0, 20);
@@ -103,20 +105,21 @@ public class PersonalChunkProvider implements IChunkProvider {
             boolean isGapChunkZ = gapWidth > 0 && intervalZ > 0 && mod(chunkZ, periodZ) >= intervalZ;
 
             if (isGapChunkX || isGapChunkZ) {
-                generateGapInChunk(
-                        chunk,
-                        chunkX,
-                        chunkZ,
-                        groundLevel,
-                        bYChunk,
-                        cfg,
-                        isGapChunkX,
-                        isGapChunkZ,
-                        periodX,
-                        periodZ,
-                        gapWidth,
-                        intervalX,
-                        intervalZ);
+                for (int surfaceLevel : surfaceLevels) {
+                    generateGapInChunk(
+                            chunk,
+                            chunkX,
+                            chunkZ,
+                            surfaceLevel,
+                            cfg,
+                            isGapChunkX,
+                            isGapChunkZ,
+                            periodX,
+                            periodZ,
+                            gapWidth,
+                            intervalX,
+                            intervalZ);
+                }
             }
 
             boolean isBoundaryX, prevBoundaryX, isBoundaryZ, prevBoundaryZ;
@@ -147,84 +150,88 @@ public class PersonalChunkProvider implements IChunkProvider {
             if (canDrawBoundary && !isGapChunkX
                     && !isGapChunkZ
                     && (isBoundaryX || prevBoundaryX || isBoundaryZ || prevBoundaryZ)) {
-                ExtendedBlockStorage ebs = chunk.getBlockStorageArray()[bYChunk];
-                if (ebs == null) {
-                    ebs = new ExtendedBlockStorage(groundLevel & ~15, true);
-                    chunk.getBlockStorageArray()[bYChunk] = ebs;
-                }
+                for (int surfaceLevel : surfaceLevels) {
+                    int yChunk = surfaceLevel >> 4;
+                    int yLocal = surfaceLevel & 15;
+                    ExtendedBlockStorage ebs = chunk.getBlockStorageArray()[yChunk];
+                    if (ebs == null) {
+                        ebs = new ExtendedBlockStorage(surfaceLevel & ~15, true);
+                        chunk.getBlockStorageArray()[yChunk] = ebs;
+                    }
 
-                for (int localZ = 0; localZ < 16; localZ++) {
-                    if (isBoundaryX) {
-                        int localX = 0;
-                        int worldX = (chunkX << 4) + localX;
-                        int worldZ = (chunkZ << 4) + localZ;
+                    for (int localZ = 0; localZ < 16; localZ++) {
+                        if (isBoundaryX) {
+                            int localX = 0;
+                            int worldX = (chunkX << 4) + localX;
+                            int worldZ = (chunkZ << 4) + localZ;
 
-                        StripeBlock stripe = getStripeBlock(
-                                worldX,
-                                worldZ,
-                                boundaryBlockA,
-                                boundaryMetaA,
-                                boundaryBlockB,
-                                boundaryMetaB);
-                        if (stripe.block != null && stripe.block != Blocks.air) {
-                            ebs.func_150818_a(localX, groundLevel & 15, localZ, stripe.block);
-                            ebs.setExtBlockMetadata(localX, groundLevel & 15, localZ, stripe.meta);
+                            StripeBlock stripe = getStripeBlock(
+                                    worldX,
+                                    worldZ,
+                                    boundaryBlockA,
+                                    boundaryMetaA,
+                                    boundaryBlockB,
+                                    boundaryMetaB);
+                            if (stripe.block != null && stripe.block != Blocks.air) {
+                                ebs.func_150818_a(localX, yLocal, localZ, stripe.block);
+                                ebs.setExtBlockMetadata(localX, yLocal, localZ, stripe.meta);
+                            }
+                        }
+
+                        if (prevBoundaryX) {
+                            int localX = 15;
+                            int worldX = (chunkX << 4) + localX;
+                            int worldZ = (chunkZ << 4) + localZ;
+
+                            StripeBlock stripe = getStripeBlock(
+                                    worldX,
+                                    worldZ,
+                                    boundaryBlockA,
+                                    boundaryMetaA,
+                                    boundaryBlockB,
+                                    boundaryMetaB);
+                            if (stripe.block != null && stripe.block != Blocks.air) {
+                                ebs.func_150818_a(localX, yLocal, localZ, stripe.block);
+                                ebs.setExtBlockMetadata(localX, yLocal, localZ, stripe.meta);
+                            }
                         }
                     }
 
-                    if (prevBoundaryX) {
-                        int localX = 15;
-                        int worldX = (chunkX << 4) + localX;
-                        int worldZ = (chunkZ << 4) + localZ;
+                    for (int localX = 0; localX < 16; localX++) {
+                        if (isBoundaryZ) {
+                            int localZ = 0;
+                            int worldX = (chunkX << 4) + localX;
+                            int worldZ = (chunkZ << 4) + localZ;
 
-                        StripeBlock stripe = getStripeBlock(
-                                worldX,
-                                worldZ,
-                                boundaryBlockA,
-                                boundaryMetaA,
-                                boundaryBlockB,
-                                boundaryMetaB);
-                        if (stripe.block != null && stripe.block != Blocks.air) {
-                            ebs.func_150818_a(localX, groundLevel & 15, localZ, stripe.block);
-                            ebs.setExtBlockMetadata(localX, groundLevel & 15, localZ, stripe.meta);
+                            StripeBlock stripe = getStripeBlock(
+                                    worldX,
+                                    worldZ,
+                                    boundaryBlockA,
+                                    boundaryMetaA,
+                                    boundaryBlockB,
+                                    boundaryMetaB);
+                            if (stripe.block != null && stripe.block != Blocks.air) {
+                                ebs.func_150818_a(localX, yLocal, localZ, stripe.block);
+                                ebs.setExtBlockMetadata(localX, yLocal, localZ, stripe.meta);
+                            }
                         }
-                    }
-                }
 
-                for (int localX = 0; localX < 16; localX++) {
-                    if (isBoundaryZ) {
-                        int localZ = 0;
-                        int worldX = (chunkX << 4) + localX;
-                        int worldZ = (chunkZ << 4) + localZ;
+                        if (prevBoundaryZ) {
+                            int localZ = 15;
+                            int worldX = (chunkX << 4) + localX;
+                            int worldZ = (chunkZ << 4) + localZ;
 
-                        StripeBlock stripe = getStripeBlock(
-                                worldX,
-                                worldZ,
-                                boundaryBlockA,
-                                boundaryMetaA,
-                                boundaryBlockB,
-                                boundaryMetaB);
-                        if (stripe.block != null && stripe.block != Blocks.air) {
-                            ebs.func_150818_a(localX, groundLevel & 15, localZ, stripe.block);
-                            ebs.setExtBlockMetadata(localX, groundLevel & 15, localZ, stripe.meta);
-                        }
-                    }
-
-                    if (prevBoundaryZ) {
-                        int localZ = 15;
-                        int worldX = (chunkX << 4) + localX;
-                        int worldZ = (chunkZ << 4) + localZ;
-
-                        StripeBlock stripe = getStripeBlock(
-                                worldX,
-                                worldZ,
-                                boundaryBlockA,
-                                boundaryMetaA,
-                                boundaryBlockB,
-                                boundaryMetaB);
-                        if (stripe.block != null && stripe.block != Blocks.air) {
-                            ebs.func_150818_a(localX, groundLevel & 15, localZ, stripe.block);
-                            ebs.setExtBlockMetadata(localX, groundLevel & 15, localZ, stripe.meta);
+                            StripeBlock stripe = getStripeBlock(
+                                    worldX,
+                                    worldZ,
+                                    boundaryBlockA,
+                                    boundaryMetaA,
+                                    boundaryBlockB,
+                                    boundaryMetaB);
+                            if (stripe.block != null && stripe.block != Blocks.air) {
+                                ebs.func_150818_a(localX, yLocal, localZ, stripe.block);
+                                ebs.setExtBlockMetadata(localX, yLocal, localZ, stripe.meta);
+                            }
                         }
                     }
                 }
@@ -254,13 +261,17 @@ public class PersonalChunkProvider implements IChunkProvider {
                                 && centerLocalZ < blockStartZ + 16) {
                             int lx = centerLocalX - blockStartX;
                             int lz = centerLocalZ - blockStartZ;
-                            ExtendedBlockStorage ebs = chunk.getBlockStorageArray()[bYChunk];
-                            if (ebs == null) {
-                                ebs = new ExtendedBlockStorage(groundLevel & ~15, true);
-                                chunk.getBlockStorageArray()[bYChunk] = ebs;
+                            for (int surfaceLevel : surfaceLevels) {
+                                int yChunk = surfaceLevel >> 4;
+                                int yLocal = surfaceLevel & 15;
+                                ExtendedBlockStorage ebs = chunk.getBlockStorageArray()[yChunk];
+                                if (ebs == null) {
+                                    ebs = new ExtendedBlockStorage(surfaceLevel & ~15, true);
+                                    chunk.getBlockStorageArray()[yChunk] = ebs;
+                                }
+                                ebs.func_150818_a(lx, yLocal, lz, centerBlock);
+                                ebs.setExtBlockMetadata(lx, yLocal, lz, centerMeta);
                             }
-                            ebs.func_150818_a(lx, groundLevel & 15, lz, centerBlock);
-                            ebs.setExtBlockMetadata(lx, groundLevel & 15, lz, centerMeta);
                         }
                     }
                 }
@@ -293,6 +304,31 @@ public class PersonalChunkProvider implements IChunkProvider {
         return chunk;
     }
 
+    private List<Integer> getExposedSurfaceLevels(List<FlatLayerInfo> layers, int worldHeight) {
+        boolean[] solid = new boolean[worldHeight];
+
+        for (FlatLayerInfo info : layers) {
+            Block block = info.func_151536_b();
+            if (block == null || block == Blocks.air) {
+                continue;
+            }
+
+            int startY = MathHelper.clamp_int(info.getMinY(), 0, worldHeight);
+            int endY = MathHelper.clamp_int(info.getMinY() + info.getLayerCount(), 0, worldHeight);
+            for (int y = startY; y < endY; y++) {
+                solid[y] = true;
+            }
+        }
+
+        List<Integer> exposed = new ArrayList<>();
+        for (int y = 0; y < worldHeight; y++) {
+            if (solid[y] && (y + 1 >= worldHeight || !solid[y + 1])) {
+                exposed.add(y);
+            }
+        }
+        return exposed;
+    }
+
     @Desugar
     private record StripeBlock(Block block, int meta) {}
 
@@ -323,13 +359,13 @@ public class PersonalChunkProvider implements IChunkProvider {
         return m < 0 ? m + b : m;
     }
 
-    private void generateGapInChunk(Chunk chunk, int chunkX, int chunkZ, int groundLevel, int bYChunk,
-            DimensionConfig cfg, boolean isGapX, boolean isGapZ, int periodX, int periodZ, int gapWidth, int intervalX,
-            int intervalZ) {
-        ExtendedBlockStorage ebs = chunk.getBlockStorageArray()[bYChunk];
+    private void generateGapInChunk(Chunk chunk, int chunkX, int chunkZ, int surfaceLevel, DimensionConfig cfg,
+            boolean isGapX, boolean isGapZ, int periodX, int periodZ, int gapWidth, int intervalX, int intervalZ) {
+        int yChunk = surfaceLevel >> 4;
+        ExtendedBlockStorage ebs = chunk.getBlockStorageArray()[yChunk];
         if (ebs == null) {
-            ebs = new ExtendedBlockStorage(groundLevel & ~15, true);
-            chunk.getBlockStorageArray()[bYChunk] = ebs;
+            ebs = new ExtendedBlockStorage(surfaceLevel & ~15, true);
+            chunk.getBlockStorageArray()[yChunk] = ebs;
         }
 
         DimensionConfig.GapPreset preset = cfg.getGapPreset();
@@ -343,7 +379,7 @@ public class PersonalChunkProvider implements IChunkProvider {
         if (gapBlockA == null || gapBlockA == Blocks.air) return;
 
         int gapWidthBlocks = gapWidth * 16;
-        int yLocal = groundLevel & 15;
+        int yLocal = surfaceLevel & 15;
 
         for (int localZ = 0; localZ < 16; localZ++) {
             for (int localX = 0; localX < 16; localX++) {

--- a/src/main/resources/assets/personalspace/lang/en_US.lang
+++ b/src/main/resources/assets/personalspace/lang/en_US.lang
@@ -62,6 +62,7 @@ gui.personalWorld.gap.c.short=C
 gui.personalWorld.gap.widthRange=0-5
 gui.personalWorld.gap.preset.ROAD=Road
 gui.personalWorld.gap.preset.SOLID=Solid
+gui.personalWorld.applyToAllSurfaceLayers=Apply to all surface layers
 gui.personalWorld.gap.blockNotAllowed.a=Gap A block not allowed
 gui.personalWorld.gap.blockNotAllowed.b=Gap B block not allowed
 gui.personalWorld.gap.blockNotAllowed.c=Gap C block not allowed

--- a/src/main/resources/assets/personalspace/lang/zh_CN.lang
+++ b/src/main/resources/assets/personalspace/lang/zh_CN.lang
@@ -60,6 +60,7 @@ gui.personalWorld.gap.c.short=C
 gui.personalWorld.gap.widthRange=0-5
 gui.personalWorld.gap.preset.ROAD=马路
 gui.personalWorld.gap.preset.SOLID=纯方块
+gui.personalWorld.applyToAllSurfaceLayers=应用到所有表面层
 gui.personalWorld.gap.blockNotAllowed.a=隔段 A 方块不被允许
 gui.personalWorld.gap.blockNotAllowed.b=隔段 B 方块不被允许
 gui.personalWorld.gap.blockNotAllowed.c=隔段 C 方块不被允许


### PR DESCRIPTION
Adds an `applyToAllSurfaceLayers` config setting for personal dimensions.

I wanted to apply the boundary/gap/center customizations to multiple exposed layers of a personal dimension, like this:

<img width="650" height="375" alt="image" src="https://github.com/user-attachments/assets/c994a252-c428-446e-ade3-eeb8396d42d7" />

This PR adds an option to apply those customizations to every solid layer that has air directly above it. I'm calling these "surface layers" for lack of a better term:

<img width="340" height="370" alt="image" src="https://github.com/user-attachments/assets/4c7d646f-75b8-4b39-841a-25c120093931" />

The setting is off by default. It can also be controlled in preset strings with the new `|S,0` / `|S,1` section. Existing worlds and old preset strings keep the previous ground-level-only behavior.