### PR TITLE
Fix portal book animation to match vanilla

### DIFF
--- a/src/main/java/me/eigenraven/personalspace/block/PortalTileEntity.java
+++ b/src/main/java/me/eigenraven/personalspace/block/PortalTileEntity.java
@@ -13,6 +13,10 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.world.BlockEvent;
 
+import java.util.Random;
+
+import net.minecraft.util.MathHelper;
+
 import me.eigenraven.personalspace.PersonalSpaceMod;
 import me.eigenraven.personalspace.config.Config;
 import me.eigenraven.personalspace.net.Packets;
@@ -24,6 +28,14 @@ public class PortalTileEntity extends TileEntity {
 
     public static final ForgeDirection DEFAULT_FACING = ForgeDirection.NORTH;
 
+    // Client-side book animation state (matches TileEntityEnchantmentTable fields)
+    public int tickCount;
+    public float pagePosition;
+    public float prevPagePosition;
+    public float pageTarget;
+    public float pageVelocity;
+    private static final Random RAND = new Random();
+
     public boolean active = false;
     public int targetDimId = 0;
     public int targetPosX = 8;
@@ -33,6 +45,27 @@ public class PortalTileEntity extends TileEntity {
     public ForgeDirection facing = DEFAULT_FACING;
 
     public PortalTileEntity() {}
+
+    @Override
+    public void updateEntity() {
+        super.updateEntity();
+        if (!worldObj.isRemote) return;
+
+        prevPagePosition = pagePosition;
+
+        if (RAND.nextInt(40) == 0) {
+            float prev = pageTarget;
+            do {
+                pageTarget += (float) (RAND.nextInt(4) - RAND.nextInt(4));
+            } while (prev == pageTarget);
+        }
+
+        ++tickCount;
+        float delta = (pageTarget - pagePosition) * 0.4F;
+        delta = MathHelper.clamp_float(delta, -0.2F, 0.2F);
+        pageVelocity += (delta - pageVelocity) * 0.9F;
+        pagePosition += pageVelocity;
+    }
 
     @Override
     public void readFromNBT(NBTTagCompound tag) {

--- a/src/main/java/me/eigenraven/personalspace/block/PortalTileEntity.java
+++ b/src/main/java/me/eigenraven/personalspace/block/PortalTileEntity.java
@@ -1,5 +1,7 @@
 package me.eigenraven.personalspace.block;
 
+import java.util.Random;
+
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
@@ -7,15 +9,12 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.world.BlockEvent;
-
-import java.util.Random;
-
-import net.minecraft.util.MathHelper;
 
 import me.eigenraven.personalspace.PersonalSpaceMod;
 import me.eigenraven.personalspace.config.Config;

--- a/src/main/java/me/eigenraven/personalspace/block/RenderPortal.java
+++ b/src/main/java/me/eigenraven/personalspace/block/RenderPortal.java
@@ -21,23 +21,25 @@ public class RenderPortal extends TileEntitySpecialRenderer {
         }
         GL11.glPushMatrix();
         GL11.glTranslatef((float) x + 0.5F, (float) y + 0.75F, (float) z + 0.5F);
-        float time = ((float) tile.getWorldObj().getWorldInfo().getWorldTotalTime() + partialTickTime) / 100.0F;
-        GL11.glTranslatef(0.0F, 0.1F + MathHelper.sin(time * 0.1F) * 0.01F, 0.0F);
+
+        float f1 = (float) portal.tickCount + partialTickTime;
+        GL11.glTranslatef(0.0F, 0.1F + MathHelper.sin(f1 * 0.1F) * 0.01F, 0.0F);
 
         float f3 = (float) Math.atan2(portal.facing.offsetZ, portal.facing.offsetX);
         GL11.glRotatef(-f3 * 180.0F / (float) Math.PI, 0.0F, 1.0F, 0.0F);
         GL11.glRotatef(80.0F, 0.0F, 0.0F, 1.0F);
         this.bindTexture(field_147540_b);
-        float pageRightAngle = 0.3F;
-        float pageLeftAngle = 0.9F;
-        pageRightAngle = (pageRightAngle - (float) MathHelper.truncateDoubleToInt(pageRightAngle)) * 1.6F - 0.3F;
-        pageLeftAngle = (pageLeftAngle - (float) MathHelper.truncateDoubleToInt(pageLeftAngle)) * 1.6F - 0.3F;
-        pageRightAngle = MathHelper.clamp_float(pageRightAngle, 0.0F, 1.0F);
-        pageLeftAngle = MathHelper.clamp_float(pageLeftAngle, 0.0F, 1.0F);
 
-        float f6 = 0.75F + 0.1F * (float) Math.sin(time);
+        float interpPage = portal.prevPagePosition + (portal.pagePosition - portal.prevPagePosition) * partialTickTime;
+        float f4 = interpPage + 0.25F;
+        float f5 = interpPage + 0.75F;
+        f4 = (f4 - (float) MathHelper.truncateDoubleToInt(f4)) * 1.6F - 0.3F;
+        f5 = (f5 - (float) MathHelper.truncateDoubleToInt(f5)) * 1.6F - 0.3F;
+        f4 = MathHelper.clamp_float(f4, 0.0F, 1.0F);
+        f5 = MathHelper.clamp_float(f5, 0.0F, 1.0F);
+
         GL11.glEnable(GL11.GL_CULL_FACE);
-        this.bookModel.render(null, time, pageRightAngle, pageLeftAngle, f6, 0.0F, 0.0625F);
+        this.bookModel.render(null, f1, f4, f5, 1.0F, 0.0F, 0.0625F);
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/me/eigenraven/personalspace/block/RenderPortal.java
+++ b/src/main/java/me/eigenraven/personalspace/block/RenderPortal.java
@@ -22,24 +22,24 @@ public class RenderPortal extends TileEntitySpecialRenderer {
         GL11.glPushMatrix();
         GL11.glTranslatef((float) x + 0.5F, (float) y + 0.75F, (float) z + 0.5F);
 
-        float f1 = (float) portal.tickCount + partialTickTime;
-        GL11.glTranslatef(0.0F, 0.1F + MathHelper.sin(f1 * 0.1F) * 0.01F, 0.0F);
+        float animTick = (float) portal.tickCount + partialTickTime;
+        GL11.glTranslatef(0.0F, 0.1F + MathHelper.sin(animTick * 0.1F) * 0.01F, 0.0F);
 
-        float f3 = (float) Math.atan2(portal.facing.offsetZ, portal.facing.offsetX);
-        GL11.glRotatef(-f3 * 180.0F / (float) Math.PI, 0.0F, 1.0F, 0.0F);
+        float facingAngle = (float) Math.atan2(portal.facing.offsetZ, portal.facing.offsetX);
+        GL11.glRotatef(-facingAngle * 180.0F / (float) Math.PI, 0.0F, 1.0F, 0.0F);
         GL11.glRotatef(80.0F, 0.0F, 0.0F, 1.0F);
         this.bindTexture(field_147540_b);
 
         float interpPage = portal.prevPagePosition + (portal.pagePosition - portal.prevPagePosition) * partialTickTime;
-        float f4 = interpPage + 0.25F;
-        float f5 = interpPage + 0.75F;
-        f4 = (f4 - (float) MathHelper.truncateDoubleToInt(f4)) * 1.6F - 0.3F;
-        f5 = (f5 - (float) MathHelper.truncateDoubleToInt(f5)) * 1.6F - 0.3F;
-        f4 = MathHelper.clamp_float(f4, 0.0F, 1.0F);
-        f5 = MathHelper.clamp_float(f5, 0.0F, 1.0F);
+        float rightPageFlip = interpPage + 0.25F;
+        float leftPageFlip = interpPage + 0.75F;
+        rightPageFlip = (rightPageFlip - (float) MathHelper.truncateDoubleToInt(rightPageFlip)) * 1.6F - 0.3F;
+        leftPageFlip = (leftPageFlip - (float) MathHelper.truncateDoubleToInt(leftPageFlip)) * 1.6F - 0.3F;
+        rightPageFlip = MathHelper.clamp_float(rightPageFlip, 0.0F, 1.0F);
+        leftPageFlip = MathHelper.clamp_float(leftPageFlip, 0.0F, 1.0F);
 
         GL11.glEnable(GL11.GL_CULL_FACE);
-        this.bookModel.render(null, f1, f4, f5, 1.0F, 0.0F, 0.0625F);
+        this.bookModel.render(null, animTick, rightPageFlip, leftPageFlip, 1.0F, 0.0F, 0.0625F);
         GL11.glPopMatrix();
     }
 }


### PR DESCRIPTION
The book animation was driven by world time divided by 100, making it run 100x slower than the vanilla enchanting table renderer (RenderEnchantmentTable). Page angles were also hardcoded constants instead of animating.

This PR aligns the animation speed and page-turning behavior with vanilla by replicating the same tick counter and interpolated page state used in TileEntityEnchantmentTable.

|Before|After|
|-|-|
|<img  alt="javaw_B00XABj5ri" src="https://github.com/user-attachments/assets/3806e1ff-97c0-46ac-a4a8-0761b54e2a59" />|<img  alt="java_LU1j0epAmQ" src="https://github.com/user-attachments/assets/d61f2088-f81c-4b3b-878d-318278f21c30" />| 


